### PR TITLE
chore: rename from create-vue-next to @selemondev/create-vue3-app

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Every significant change is documented in the changelog file.
 
 ## Reporting Issues
 
-Welcome to Create-Vue-Next CLI! We value your feedback and contributions to make this project better. If you encounter any bugs or have feature requests, please use [Github issues](https://github.com/selemondev/create-vue-next/issues) issues to submit them.
+Welcome to Init-Vue3-App CLI! We value your feedback and contributions to make this project better. If you encounter any bugs or have feature requests, please use [Github issues](https://github.com/selemondev/init-vue3-app/issues) issues to submit them.
 
 Before reporting an issue, we ask you to:
 
@@ -50,19 +50,19 @@ The following is a list of commit types:
 
 ### Commit Types:
 
-- `feat`: Adding a new snippet or significant functionality to the Create-Vue-Next CLI.
+- `feat`: Adding a new snippet or significant functionality to the Init-Vue3-App CLI.
 
-- `fix`: Addressing bugs or issues in existing Create-Vue-Next CLI.
+- `fix`: Addressing bugs or issues in existing Init-Vue3-App CLI.
 
-- `docs`: Commits related to documentation changes for Create-Vue-Next CLI.
+- `docs`: Commits related to documentation changes for Init-Vue3-App CLI.
 
-- `style`: Commits related to code formatting, styling, or theming of Create-Vue-Next CLI.
+- `style`: Commits related to code formatting, styling, or theming of Init-Vue3-App CLI.
 
 - `refactor`: Code changes that enhance the library's structure without introducing new features or fixing bugs.
 
-- `perf`: Commits aimed at improving performance for Create-Vue-Next CLI.
+- `perf`: Commits aimed at improving performance for Init-Vue3-App CLI.
 
-- `test`: Commits related to testing Create-Vue-Next CLI.
+- `test`: Commits related to testing Init-Vue3-App CLI.
 
 - `chore`: Other commits not affecting source or test files directly.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Every significant change is documented in the changelog file.
 
 ## Reporting Issues
 
-Welcome to Init-Vue3-App CLI! We value your feedback and contributions to make this project better. If you encounter any bugs or have feature requests, please use [Github issues](https://github.com/selemondev/init-vue3-app/issues) issues to submit them.
+Welcome to Create-Vue3-App CLI! We value your feedback and contributions to make this project better. If you encounter any bugs or have feature requests, please use [Github issues](https://github.com/selemondev/create-vue3-app/issues) issues to submit them.
 
 Before reporting an issue, we ask you to:
 
@@ -50,19 +50,19 @@ The following is a list of commit types:
 
 ### Commit Types:
 
-- `feat`: Adding a new snippet or significant functionality to the Init-Vue3-App CLI.
+- `feat`: Adding a new snippet or significant functionality to the Create-Vue3-App CLI.
 
-- `fix`: Addressing bugs or issues in existing Init-Vue3-App CLI.
+- `fix`: Addressing bugs or issues in existing Create-Vue3-App CLI.
 
-- `docs`: Commits related to documentation changes for Init-Vue3-App CLI.
+- `docs`: Commits related to documentation changes for Create-Vue3-App CLI.
 
-- `style`: Commits related to code formatting, styling, or theming of Init-Vue3-App CLI.
+- `style`: Commits related to code formatting, styling, or theming of Create-Vue3-App CLI.
 
 - `refactor`: Code changes that enhance the library's structure without introducing new features or fixing bugs.
 
-- `perf`: Commits aimed at improving performance for Init-Vue3-App CLI.
+- `perf`: Commits aimed at improving performance for Create-Vue3-App CLI.
 
-- `test`: Commits related to testing Init-Vue3-App CLI.
+- `test`: Commits related to testing Create-Vue3-App CLI.
 
 - `chore`: Other commits not affecting source or test files directly.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Init-Vue3-App CLI and Selemondev
+Copyright (c) 2024 Create-Vue3-App CLI and Selemondev
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Create-Vue-Next CLI and Selemondev
+Copyright (c) 2024 Init-Vue3-App CLI and Selemondev
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
  <img align="center" src="https://raw.githubusercontent.com/selemondev/create-vue-next/master/image/create-vue-next.png" height="400" />
 </p>
 
-## Create Vue Next ⚡
+## Create Vue3 App ⚡
 
 The Next Generation Vue Scaffolding Tool powered by Vite 🛠️
 
@@ -11,39 +11,39 @@ The Next Generation Vue Scaffolding Tool powered by Vite 🛠️
 ### npx
 
 ```bash
-npx create-vue-next@latest
+npx @selemondev/create-vue3-app@latest
 
 # OR
 
-npx create-vue-next <project-name> --ts --eslint --tailwind --use-pnpm
+npx @selemondev/create-vue3-app <project-name> --ts --eslint --tailwind --use-pnpm
 ```
 
 ### yarn
 
 ```bash
-yarn create vue-next
+yarn @selemondev/create-vue3-app
 
 # OR
 
-yarn create vue-next <project-name> --ts --eslint --tailwind --use-pnpm
+yarn @selemondev/create-vue3-app <project-name> --ts --eslint --tailwind --use-pnpm
 ```
 
 ### pnpm
 
 ```bash
-pnpm create vue-next@latest
+pnpm @selemondev/create-vue3-app@latest
 
 # OR
 
-pnpm create vue-next@latest <project-name> --ts --eslint --tailwind --use-pnpm
+pnpm @selemondev/create-vue3-app@latest <project-name> --ts --eslint --tailwind --use-pnpm
 ```
 
 ## Options
 
-You can also pass command line arguments to set up a new project non-interactively. Run `create-vue-next --help` to see the available command line arguments:
+You can also pass command line arguments to set up a new project non-interactively. Run `@selemondev/create-vue3-app --help` to see the available command line arguments:
 
 ```bash
-Usage: create-vue-next <project-name> [options]
+Usage: @selemondev/create-vue3-app <project-name> [options]
 
 Options:
   -V, --version   output the version number

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "create-vue-next",
-  "version": "0.0.2",
+  "name": "@selemondev/create-vue3-app",
+  "version": "0.0.3",
   "description": "The Next Generation Vue Scaffolding Tool ✨",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -21,7 +21,7 @@
     }
   },
   "bin": {
-    "create-vue-next": "./dist/index.js"
+    "@selemondev/create-vue3-app": "./dist/index.js"
   },
   "files": [
     "dist",
@@ -29,7 +29,7 @@
     "template"
   ],
   "keywords": [
-    "create-vue-next",
+    "@selemondev/create-vue3-app",
     "Vue CLI",
     "Vue 3 CLI",
     "Vite CLI",

--- a/src/core/command/create-vue-next/initialLog.ts
+++ b/src/core/command/create-vue-next/initialLog.ts
@@ -2,7 +2,7 @@ import { logger } from "../../../utils/logger";
 async function initialLog() {
     console.clear();
 
-    logger.info('Welcome To Create Vue Next. The Next Generation Vue Scaffolding Tool ✨');
+    logger.info('Welcome To Create Vue 3 App. The Next Generation Vue Scaffolding Tool ✨');
 
     console.log();
 }

--- a/src/core/command/create-vue-next/install.ts
+++ b/src/core/command/create-vue-next/install.ts
@@ -17,7 +17,7 @@ async function installDeps() {
 
     await cmdIgnore('git', ['add .'])
 
-    await cmdIgnore('git', ['commit -m "Initialized by create-vue-next"'])
+    await cmdIgnore('git', ['commit -m "Initialized by create-vue3-app"'])
   }
 
 

--- a/src/core/questions/vue/projectName.ts
+++ b/src/core/questions/vue/projectName.ts
@@ -1,7 +1,7 @@
 import options from '../../../core/utils/vue/options'
 import emptyDirName from '../../../utils/emptyDirName'
 import { validatePackageName } from "../../../utils/validatePackageName"
-const defaultProjectName = 'create-vue-next'
+const defaultProjectName = 'create-vue3-app'
 
 const packageName = [
     {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import options from './core/utils/vue/options';
 async function main() {
       program
             .version(packageJson.version)
-            .description(`Create Vue Next. The Next Generation Vue Scaffolding Tool ⚡`)
+            .description(`Create Vue3 App. The Next Generation Vue Scaffolding Tool ⚡`)
             .action((name: string) => {
                   options.name = name;
             })

--- a/template/vue-js/index.html
+++ b/template/vue-js/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <link rel="icon" href="/favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Create Vue Next</title>
+    <title>Create Vue 3 App</title>
   </head>
   <body>
     <div id="app"></div>

--- a/template/vue-js/src/components/TheWelcome.ejs
+++ b/template/vue-js/src/components/TheWelcome.ejs
@@ -113,7 +113,7 @@
 
         <div>
           <h2 class="font-sans text-4xl font semibold">
-            Welcome To Create Vue Next
+            Welcome To Create Vue 3 App
           </h2>
         </div>
 
@@ -154,7 +154,7 @@
       
             <div>
               <h2 class="title">
-                Welcome To Create Vue Next
+                Welcome To Create Vue 3 App
               </h2>
             </div>
       

--- a/template/vue-ts/index.html
+++ b/template/vue-ts/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <link rel="icon" href="/favicon.ico">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Create Vue Next</title>
+  <title>Create Vue 3 App</title>
 </head>
 
 <body>

--- a/template/vue-ts/src/components/TheWelcome.ejs
+++ b/template/vue-ts/src/components/TheWelcome.ejs
@@ -113,7 +113,7 @@
 
         <div>
           <h2 class="font-sans text-4xl font semibold">
-            Welcome To Create Vue Next
+            Welcome To Create Vue 3 App
           </h2>
         </div>
 
@@ -154,7 +154,7 @@
       
             <div>
               <h2 class="title">
-                Welcome To Create Vue Next
+                Welcome To Create Vue 3 App
               </h2>
             </div>
       


### PR DESCRIPTION
This pull request is intended to rename the package from `create-vue-next` to `@selemondev/create-vue3-app` to get rid of the confusion.